### PR TITLE
Some changes for determinant output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.com/VALENCE-software/VALENCE.svg?branch=master)](https://travis-ci.com/VALENCE-software/VALENCE)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/VALENCE-software/VALENCE/master?filepath=valence_tutorial.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/VALENCE-software/VALENCE/determinants?filepath=valence_tutorial.ipynb)
 [![codecov](https://codecov.io/gh/VALENCE-software/VALENCE/branch/master/graph/badge.svg)](https://codecov.io/gh/VALENCE-software/VALENCE)
 [![DOI](https://zenodo.org/badge/152630099.svg)](https://zenodo.org/badge/latestdoi/152630099)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.com/VALENCE-software/VALENCE.svg?branch=master)](https://travis-ci.com/VALENCE-software/VALENCE)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/VALENCE-software/VALENCE/determinants?filepath=valence_tutorial.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/VALENCE-software/VALENCE/master?filepath=valence_tutorial.ipynb)
 [![codecov](https://codecov.io/gh/VALENCE-software/VALENCE/branch/master/graph/badge.svg)](https://codecov.io/gh/VALENCE-software/VALENCE)
 [![DOI](https://zenodo.org/badge/152630099.svg)](https://zenodo.org/badge/latestdoi/152630099)
 

--- a/src/xm_module.F90
+++ b/src/xm_module.F90
@@ -726,6 +726,7 @@ contains
 #endif
     if ( myrank .eq. 0) then
        write( *,'(A, I20)' ) 'Average over ranks: Determinants count:', sum_determinants/ nrank
+       write( *,'(A, I20)' ) 'Total over ranks: Determinants count:', sum_determinants
     endif
 #endif
 

--- a/vtools/vtools.py
+++ b/vtools/vtools.py
@@ -38,10 +38,10 @@ def get_number_of_determinants(x):
     x: int or any object that can return a mol object with obtools get_mol()
     """
     try:
-        nelec = x + 2 - 2
+        norbital = x + 2 - 2
     except TypeError:
-        nelec = ob.get_nelectron(x) / 2
-    return int(3*norb**4/2-norb**3+15*norb**2/2-2*norb)
+        norbital = int(ob.get_nelectron(x) / 2)
+    return int(3*norbital**4/2-norbital**3+15*norbital**2/2-2*norbital)
 
 
 def get_unique_atomic_numbers(x):

--- a/vtools/vtools.py
+++ b/vtools/vtools.py
@@ -40,8 +40,8 @@ def get_number_of_determinants(x):
     try:
         nelec = x + 2 - 2
     except TypeError:
-        nelec = ob.get_nelectron(x)
-    return int(3*nelec**4/2-nelec**3+15*nelec**2/2-2*nelec)
+        nelec = ob.get_nelectron(x) / 2
+    return int(3*norb**4/2-norb**3+15*norb**2/2-2*norb)
 
 
 def get_unique_atomic_numbers(x):


### PR DESCRIPTION
Two small changes for determinant output:
- When PRINT_COUNTERS=yes in the Makefile, the output now contains both the average number of determinants calculated per rank and the total number of determinants calculated
- Modified `get_number_of_determinants` in vtools.py to use half the number of electrons instead of the number of electrons in the formula. (@keceli, could you double check if you agree with this? :) ) 