### PR TITLE
Changing executable to read from a file instead of stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ In addition, VALENCE has the ability to expand orbitals in terms of other LCAOs,
 
 Currently, VALENCE can optimize two types of linear parameter - orbital weights, and spin-coupling weights - using a first-order method. The term, 'first-order', refers to taking the first derivative of the VSVB energy with respect to the linear weights. The method solves a generalized eigenproblem of the form  HC=SCE  beginning by forming the hamiltonian (H) and overlap matrices (S), where E are the eigenvalues (energies). The eigenvectors (C) contain the updated orbital or spin-coupling weights. The cost of this method is quadratic with the size of the orbital expansion or spin-coupling space. There is currently an option to use a 'direct energy minimization' (DEM) method, though this is still under development. 
 
-VALENCE is written in Fortran-90 and runs in parallel using MPI. To compute integrals, VALENCE currently uses the vectorized integral package, SIMINT (https://github.com/simint-chem). This release includes instructions on how to build SIMINT. Once the SIMINT library is built, building VALENCE itself begins with setting options in a simple Makefile. The Makefile also contains some optimizations for various platforms, and an option to build the sequential form. A binary called 'valence' should result. VALENCE takes an input file on standard input. To run VALENCE sequentially just type,
+VALENCE is written in Fortran-90 and runs in parallel using MPI. To compute integrals, VALENCE currently uses the vectorized integral package, SIMINT (https://github.com/simint-chem). This release includes instructions on how to build SIMINT. Once the SIMINT library is built, building VALENCE itself begins with setting options in a simple Makefile. The Makefile also contains some optimizations for various platforms, and an option to build the sequential form. A binary called 'valence' should result. VALENCE takes an input file on the command line. To run VALENCE sequentially just type,
 
-`./valence < [name of input file]`
+`./valence [name of input file]`
 
 See section 5 for example input files. To run VALENCE in parallel, please consult the documentation for your target platform as to how MPI runs are specified.
 

--- a/examples/test_all
+++ b/examples/test_all
@@ -22,7 +22,7 @@ fi
   then
       for i in ${examples[@]}
       do
-          ../bin/$1 < ./$i > $i.out
+          ../bin/$1 ./$i > $i.out
           python ./test_examples.py $i.out $i
       done
   else

--- a/src/valence_initialize_module.F90
+++ b/src/valence_initialize_module.F90
@@ -52,10 +52,8 @@ subroutine read_allocate_input
   if( len_trim(input_file) == 0 ) call xm_abort('must have one input file;')
   open( unit=file_input_unit, file=input_file, status="old", iostat=ios,readonly )
   if( .not. ios .eq. 0 ) call xm_abort('problems opening input file;')
-
-! needs to be closed at some point
-!  close( 100 )
 #endif
+
   call xm_getdims( natom,natom_t, npair,nunpd,ndocc, totlen,  &
        xpmax,nspinc, num_sh,num_pr,nang, ndf,nset_in,nxorb, mxctr_in )
   if ( npair .gt. 0 .and. nspinc .lt. 1 ) call xm_abort('no spin couplings;')

--- a/src/valence_initialize_module.F90
+++ b/src/valence_initialize_module.F90
@@ -42,7 +42,16 @@ subroutine read_allocate_input
   integer i,k,j,ierr,mnshi,mxshi
   real(dp)      zero,         ten,            rln10
   parameter  ( zero = 0.0_dp, ten = 10.0_dp, rln10=2.30258_dp )
+  character(len=1000) :: input_file
 
+! read in the input file
+#ifdef FILE_IN 
+ call get_command_argument(1, input_file)
+  if( len_trim(input_file) == 0 ) call xm_abort('must have one input file')
+  open( unit=100, file=input_file )
+! needs to be closed at some point
+!  close( 100 )
+#endif
   call xm_getdims( natom,natom_t, npair,nunpd,ndocc, totlen,  &
        xpmax,nspinc, num_sh,num_pr,nang, ndf,nset_in,nxorb, mxctr_in )
   if ( npair .gt. 0 .and. nspinc .lt. 1 ) call xm_abort('no spin couplings;')

--- a/src/valence_initialize_module.F90
+++ b/src/valence_initialize_module.F90
@@ -46,11 +46,10 @@ subroutine read_allocate_input
 
 ! read in the input file
 #ifndef USE_STDIN 
-! set whatever to use for input unit, which is stored in the xm module
-  file_input_unit=100
  call get_command_argument(1, input_file)
   if( len_trim(input_file) == 0 ) call xm_abort('must have one input file;')
-  open( unit=file_input_unit, file=input_file, status="old", iostat=ios,readonly )
+  open( unit=file_input_unit, file=input_file, status="old", &
+       iostat=ios,action='read' )
   if( .not. ios .eq. 0 ) call xm_abort('problems opening input file;')
 #endif
 

--- a/src/valence_initialize_module.F90
+++ b/src/valence_initialize_module.F90
@@ -39,16 +39,20 @@ subroutine read_allocate_input
 
   integer mxctr_in, nset_in,max_iter_in
   integer      ntol_c,ntol_d,ntol_i, ntol_e_min_in,ntol_e_max_in
-  integer i,k,j,ierr,mnshi,mxshi
+  integer i,k,j,ierr,mnshi,mxshi,ios
   real(dp)      zero,         ten,            rln10
   parameter  ( zero = 0.0_dp, ten = 10.0_dp, rln10=2.30258_dp )
   character(len=1000) :: input_file
 
 ! read in the input file
-#ifdef FILE_IN 
+#ifndef USE_STDIN 
+! set whatever to use for input unit, which is stored in the xm module
+  file_input_unit=100
  call get_command_argument(1, input_file)
-  if( len_trim(input_file) == 0 ) call xm_abort('must have one input file')
-  open( unit=100, file=input_file )
+  if( len_trim(input_file) == 0 ) call xm_abort('must have one input file;')
+  open( unit=file_input_unit, file=input_file, status="old", iostat=ios,readonly )
+  if( .not. ios .eq. 0 ) call xm_abort('problems opening input file;')
+
 ! needs to be closed at some point
 !  close( 100 )
 #endif
@@ -110,6 +114,11 @@ subroutine read_allocate_input
   ctol = rln10*dble( ntol_c  )
   dtol =     ten**( -ntol_d  )
   itol =     ten**( -ntol_i )
+
+#ifndef USE_STDIN 
+! needs to be closed at some point
+  close( unit=file_input_unit )
+#endif
 
 end subroutine read_allocate_input
 end module valence_init

--- a/src/valence_initialize_module.F90
+++ b/src/valence_initialize_module.F90
@@ -48,7 +48,7 @@ subroutine read_allocate_input
 #ifndef USE_STDIN 
  call get_command_argument(1, input_file)
   if( len_trim(input_file) == 0 ) call xm_abort('must have one input file;')
-  open( unit=file_input_unit, file=input_file, status="old", &
+  open( newunit=file_input_unit, file=input_file, status="old", &
        iostat=ios,action='read' )
   if( .not. ios .eq. 0 ) call xm_abort('problems opening input file;')
 #endif

--- a/src/xm_module.F90
+++ b/src/xm_module.F90
@@ -18,7 +18,7 @@ module xm
   integer :: nrank
   integer :: irank
 ! this is the input file unit number
-  integer, parameter :: file_input_unit = 100
+  integer, parameter :: file_input_unit = 20
 
 contains
 

--- a/src/xm_module.F90
+++ b/src/xm_module.F90
@@ -17,7 +17,8 @@ module xm
   integer :: valence_global_communicator
   integer :: nrank
   integer :: irank
-  integer :: file_input_unit
+! this is the input file unit number
+  integer, parameter :: file_input_unit = 100
 
 contains
 

--- a/src/xm_module.F90
+++ b/src/xm_module.F90
@@ -18,7 +18,7 @@ module xm
   integer :: nrank
   integer :: irank
 ! this is the input file unit number
-  integer, parameter :: file_input_unit = 20
+  integer :: file_input_unit
 
 contains
 

--- a/src/xm_module.F90
+++ b/src/xm_module.F90
@@ -35,8 +35,13 @@ contains
 
     call xm_inherit( nproc, myrank, master )
 
+#ifdef FILE_IN
+    if ( myrank .eq. master ) read(100,*) natom,natom_t, npair,nunpd,ndocc,  &
+         totlen,xpmax, nspinc, num_sh,num_pr,nang, ndf,nset,nxorb, mxctr
+#else
     if ( myrank .eq. master ) read *, natom,natom_t, npair,nunpd,ndocc,  &
          totlen,xpmax, nspinc, num_sh,num_pr,nang, ndf,nset,nxorb, mxctr
+#endif
 
 #ifdef VALENCE_MPI
     from = 0
@@ -95,15 +100,24 @@ contains
 
        !     optimization control 
 
+#ifdef FILE_IN
+       read(100,*)  ntol_c, ntol_d, ntol_i, &
+            ntol_e_min_in, ntol_e_max_in, max_iter_in, ptbnmax,feather,  &
+            ( orbset( 1, i ), orbset( 2, i ), i = 1, nset )
+#else
        read *,  ntol_c, ntol_d, ntol_i, &
             ntol_e_min_in, ntol_e_max_in, max_iter_in, ptbnmax,feather,  &
             ( orbset( 1, i ), orbset( 2, i ), i = 1, nset )
-
+#endif
 
        !     input the cartesian geometry 
 
        do    i  =  1,  natom
+#ifdef FILE_IN
+          read(100,*)  atom_t( i ), (coords( j, i ), j=1,3)
+#else
           read *,  atom_t( i ), (coords( j, i ), j=1,3)
+#endif
        end   do
 
 
@@ -113,22 +127,36 @@ contains
        np = 1
        do    i  =  1,  natom_t
           map_atom2shell( i ) = ns
-
+#ifdef FILE_IN
+          read(100,*)  nuc_charge( i ),  nshell
+#else
           read *,  nuc_charge( i ),  nshell
+#endif
           num_shell_atom( i ) = nshell
           do    j  =  1,  nshell
              map_shell2prim( ns ) = np
+#ifdef FILE_IN
+             read(100,*)  ang_mom( ns ), con_length
+#else
              read *,  ang_mom( ns ), con_length
-
+#endif
              !     avoid redundant input of unit weight for uncontracted GTO
 
              if ( con_length .eq. 1 ) then
+#ifdef FILE_IN
+                read(100,*)  exponent( np )
+#else
                 read *,  exponent( np )
+#endif
                 unnormalized_con_coeff( np ) = 1.0d+00
                 np = np + 1
              else
                 do    k  =  1,  con_length
+#ifdef FILE_IN
+                   read(100,*) exponent( np ), unnormalized_con_coeff( np )
+#else
                    read *,  exponent( np ), unnormalized_con_coeff( np )
+#endif
                    np = np + 1
                 end   do
              end if
@@ -149,18 +177,30 @@ contains
 
        coeff_sc( 1 ) = 1.0d+00
        if ( npair .gt. 0 ) then
+#ifdef FILE_IN
+          if ( nspinc .eq. 1 ) then
+             read(100,*) ( pair_sc( i, 1, 1 ), pair_sc( i, 2, 1 ), i = 1, npair )
+          else  if ( nspinc .gt. 1 ) then
+             read(100,*) ( coeff_sc( j ), ( pair_sc( i, 1, j ),  &
+                  pair_sc( i, 2, j ), i = 1, npair ), j = 1, nspinc )
+          end if
+#else
           if ( nspinc .eq. 1 ) then
              read *, ( pair_sc( i, 1, 1 ), pair_sc( i, 2, 1 ), i = 1, npair )
           else  if ( nspinc .gt. 1 ) then
              read *, ( coeff_sc( j ), ( pair_sc( i, 1, j ),  &
                   pair_sc( i, 2, j ), i = 1, npair ), j = 1, nspinc )
           end if
+#endif
        end if
 
        !     input the excited orbitals and roots
 
+#ifdef FILE_IN
+       if( nxorb .gt. 0 ) read(100,*) ( xorb( i ), root( i ), i = 1, nxorb )
+#else
        if( nxorb .gt. 0 ) read *, ( xorb( i ), root( i ), i = 1, nxorb )
-
+#endif
 
 
        !     input the wave function; 
@@ -168,44 +208,80 @@ contains
 
        j  =  1
        do     i = 1, 2*npair
+#ifdef FILE_IN
+          read(100,*)   orbas_atnum( i ),   &
+               ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
+          map_orbs( i )  =  j
+          read(100,*) ( xpset( k ), coeff( k ), k = j, j + n - 1 )
+          j  =  j  +  n
+#else
           read *,   orbas_atnum( i ),   &
                ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
           map_orbs( i )  =  j
           read *, ( xpset( k ), coeff( k ), k = j, j + n - 1 )
           j  =  j  +  n
+
+#endif
        end   do
 
 
        !     input unpaired orbitals
 
        do     i = 2*npair + 1, 2*npair + nunpd
+#ifdef FILE_IN
+          read(100,*)  orbas_atnum( i ),   &
+               ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
+          map_orbs( i )  =  j
+          read(100,*) ( xpset( k ), coeff( k ), k = j, j + n - 1 )
+          j  =  j  +  n
+#else
           read *,   orbas_atnum( i ),   &
                ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
           map_orbs( i )  =  j
           read *, ( xpset( k ), coeff( k ), k = j, j + n - 1 )
           j  =  j  +  n
+
+#endif
        end   do
 
 
        !     input doubly-occupied orbitals
 
        do     i = 2*npair + nunpd + 1, 2*npair + nunpd + ndocc
+#ifdef FILE_IN
+          read(100,*)   orbas_atnum( i ),   &
+               ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
+          map_orbs( i )  =  j
+          read(100,*) ( xpset( k ), coeff( k ), k = j, j + n - 1 )
+          j  =  j  +  n
+#else
           read *,   orbas_atnum( i ),   &
                ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
           map_orbs( i )  =  j
           read *, ( xpset( k ), coeff( k ), k = j, j + n - 1 )
           j  =  j  +  n
+
+#endif
        end   do
 
 
        !     input NDF's
 
        do     i = 2*npair + nunpd + ndocc + 1, 2*npair + nunpd + ndocc + ndf
+#ifdef FILE_IN
+          read(100,*)   orbas_atnum( i ),   &
+               ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
+          map_orbs( i )  =  j
+          read(100,*) ( xpset( k ), coeff( k ), k = j, j + n - 1 )
+          j  =  j  +  n
+#else
           read *,   orbas_atnum( i ),   &
                ( orbas_atset( k, i ), k = 1, orbas_atnum( i ) ),   n
           map_orbs( i )  =  j
           read *, ( xpset( k ), coeff( k ), k = j, j + n - 1 )
           j  =  j  +  n
+
+#endif
        end   do
        norbs  =  2*npair  +  nunpd  +  ndocc + ndf
        map_orbs( norbs  +  1 )  =  j

--- a/testing/test_script
+++ b/testing/test_script
@@ -70,13 +70,13 @@ LOGFILE=${datestamp}/testing.log
       do
           OUTPUT=${datestamp}/${i}_$datestamp.out
           if [ $NCORE -gt 1 ]; then
-          	mpirun -n $NCORE $1 < ./test_cases/$i > $OUTPUT
+          	mpirun -n $NCORE $1 ./test_cases/$i > $OUTPUT
             if [ "$?" -ne "0" ]; then
 	      cat $OUTPUT
               exit 1
             fi
           else
-            $1 < ./test_cases/$i > $OUTPUT
+            $1 ./test_cases/$i > $OUTPUT
             if [ "$?" -ne "0" ]; then
 	      cat $OUTPUT
               exit 1


### PR DESCRIPTION
This changes the default behavior of VALENCE so that it reads from a file given on the command line instead of from stdin., that is, it is now:
```
./bin/valence path/inputfile.inp 
```
There is a limit on the filename being < 1000 characters.

To revert back to old behavior, recompile with `-DUSE_STDIN`. In the future, maybe we can remove this option entirely, since I think reading from a file is probably better in general than from stdin.

The testing scripts and example scripts have been updated, but let me know if anything is missed.
